### PR TITLE
updating github actions cache to be v4 as previous versions are depre…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
Updated Github Actions Cache to be version 4 as previous versions are deprecated.